### PR TITLE
directional_bcs

### DIFF
--- a/flooddrake/boundary_conditions.py
+++ b/flooddrake/boundary_conditions.py
@@ -7,6 +7,9 @@ from __future__ import absolute_import
 # boundary condition options
 options = ['solid wall', 'inflow', 'outflow']
 
+# horizontal directions
+directions = ['both', 'x', 'y']
+
 
 class BoundaryConditions(object):
 
@@ -31,11 +34,12 @@ class BoundaryConditions(object):
 
     """
 
-    def __init__(self, marker, option='solid wall', value=None):
+    def __init__(self, marker, option='solid wall', value=None, direction='both'):
 
         self.option = option
         self.value = value
         self.marker = marker
+        self.direction = direction
 
         if self.option not in options:
             raise ValueError('bc option must be either solid wall, inflow or outflow')
@@ -44,8 +48,12 @@ class BoundaryConditions(object):
         if self.option == 'outflow' or self.option == 'solid wall':
             self.value = None
 
-        if self.option == 'river':
+        if self.option == 'inflow':
             if self.value is None:
-                raise ValueError('river bc option needs w specified at boundary')
+                raise ValueError('inflow bc option needs w specified at boundary')
+
+        # check that one of directions is given
+        if self.direction not in directions:
+            raise ValueError('horizontal direction of condition must either be both, x or y')
 
         super(BoundaryConditions, self).__init__()

--- a/flooddrake/flux.py
+++ b/flooddrake/flux.py
@@ -245,6 +245,7 @@ def Boundary_Flux(V, w, bc):
         h, mu, mv = split(w)
 
         # iterate through bc's
+        Directions = ['x', 'y']
         for b in bc:
 
             if b.direction is 'both':
@@ -279,6 +280,9 @@ def Boundary_Flux(V, w, bc):
                     hr = h
                     hl = h
 
+                Directions.remove('x')
+                Directions.remove('y')
+
             if b.direction is 'x':
 
                 if b.option == 'solid wall':
@@ -302,6 +306,8 @@ def Boundary_Flux(V, w, bc):
                     hr = h
                     hl = h
 
+                Directions.remove('x')
+
             if b.direction is 'y':
 
                 if b.option == 'solid wall':
@@ -324,6 +330,11 @@ def Boundary_Flux(V, w, bc):
 
                     hr = h
                     hl = h
+
+                Directions.remove('y')
+
+        # check all directions of momentum are defined
+        assert len(Directions) == 0
 
         # Do HLLC flux
         ul = conditional(hl <= 0, zero(as_vector((mul / hl, mvl / hl)).ufl_shape),

--- a/flooddrake/flux.py
+++ b/flooddrake/flux.py
@@ -199,7 +199,7 @@ def Boundary_Flux(V, w, bc):
             mur = mu
             mul = bc[0].value.sub(1)
             hr = h
-            hl = bc[0].value.sub(0)
+            hl = h
 
         if bc[0].option == 'outflow':
             mur = mu

--- a/tests/test_boundary_conditions.py
+++ b/tests/test_boundary_conditions.py
@@ -105,6 +105,90 @@ def test_default_boundaries_2d():
             assert solution.boundary_conditions[i].value is None
 
 
+def test_default_boundaries_2d_directions():
+
+    n = 10
+    mesh = UnitSquareMesh(n, n)
+
+    # mixed function space
+    v_h = FunctionSpace(mesh, "DG", 1)
+    v_mu = FunctionSpace(mesh, "DG", 1)
+    v_mv = FunctionSpace(mesh, "DG", 1)
+    V = v_h * v_mu * v_mv
+
+    # setup bed
+    bed = Function(V)
+
+    # source term
+    source = Function(v_h)
+
+    # boundary - only give one boundary
+    boundary_w = Function(V)
+    marker = 2
+    boundary_conditions = [BoundaryConditions(marker, option='inflow', value=boundary_w,
+                                              direction='x'),
+                           BoundaryConditions(marker, option='inflow', value=boundary_w,
+                                              direction='y')]
+
+    # timestep
+    solution = Timestepper(V, bed, source, 0.025, boundary_conditions=boundary_conditions)
+
+    # check bcs
+    dirs = ['x', 'y']
+    for i in range(len(solution.boundary_conditions)):
+        print i
+        print solution.boundary_conditions[i].marker
+        if solution.boundary_conditions[i].marker == marker:
+            print solution.boundary_conditions[i].direction
+            assert solution.boundary_conditions[i].option == 'inflow'
+            assert solution.boundary_conditions[i].direction in dirs
+        else:
+            assert solution.boundary_conditions[i].option == 'solid wall'
+            assert solution.boundary_conditions[i].value is None
+            assert solution.boundary_conditions[i].direction is 'both'
+
+
+def test_default_boundaries_2d_boundary_directions_default():
+
+    n = 10
+    mesh = UnitSquareMesh(n, n)
+
+    # mixed function space
+    v_h = FunctionSpace(mesh, "DG", 1)
+    v_mu = FunctionSpace(mesh, "DG", 1)
+    v_mv = FunctionSpace(mesh, "DG", 1)
+    V = v_h * v_mu * v_mv
+
+    # setup bed
+    bed = Function(V)
+
+    # source term
+    source = Function(v_h)
+
+    # boundary - only give one boundary
+    boundary_w = Function(V)
+    marker = 2
+    boundary_conditions = [BoundaryConditions(marker, option='inflow', value=boundary_w,
+                                              direction='x')]
+
+    # timestep
+    solution = Timestepper(V, bed, source, 0.025, boundary_conditions=boundary_conditions)
+
+    # check bcs
+    dirs = ['x', 'y']
+    for i in range(len(solution.boundary_conditions)):
+        if solution.boundary_conditions[i].marker == marker:
+            if solution.boundary_conditions[i].direction == 'x':
+                assert solution.boundary_conditions[i].option == 'inflow'
+            if solution.boundary_conditions[i].direction == 'y':
+                assert solution.boundary_conditions[i].option == 'solid wall'
+            assert solution.boundary_conditions[i].direction in dirs
+        else:
+            assert solution.boundary_conditions[i].option == 'solid wall'
+            assert solution.boundary_conditions[i].value is None
+            assert solution.boundary_conditions[i].direction is 'both'
+
+
 if __name__ == "__main__":
     import os
     import pytest

--- a/tests/test_boundary_conditions.py
+++ b/tests/test_boundary_conditions.py
@@ -136,10 +136,7 @@ def test_default_boundaries_2d_directions():
     # check bcs
     dirs = ['x', 'y']
     for i in range(len(solution.boundary_conditions)):
-        print i
-        print solution.boundary_conditions[i].marker
         if solution.boundary_conditions[i].marker == marker:
-            print solution.boundary_conditions[i].direction
             assert solution.boundary_conditions[i].option == 'inflow'
             assert solution.boundary_conditions[i].direction in dirs
         else:


### PR DESCRIPTION
**Alterations:**

- Allow directions 'x', 'y' and 'both' (both being default) to be specified for each boundary condition in 2D problems. In 1D, it will default by being the only horizontal component.
- Made tests to test default solid walls on direction not specified and to check we can specify each direction
- Tidy up of some assertions and arguments in `flux.py` that didn't need to be there. E.g. `flux.py` now takes just `BoundaryCondition` objects.